### PR TITLE
Add ingredient icons to soup recipes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import "./App.css";
+
 import React, { useState } from "react";
-import { ingredients } from "./services/SoupService";
-import SoupList from "./components/SoupList";
+
+import { INGREDIENTS } from "./services/IngredientService";
 import IngredientPicker from "./components/IngredientPicker";
+import SoupList from "./components/SoupList";
 
 interface AppContextInterface {
   toggledIngredients: boolean[];
@@ -13,7 +15,7 @@ export const AppContext = React.createContext<AppContextInterface | null>(null);
 
 function App() {
   const [toggledIngredients, setToggledIngredients] = useState(
-    new Array(ingredients.length).fill(false) as boolean[]
+    new Array(INGREDIENTS.length).fill(false) as boolean[]
   );
 
   return (

--- a/src/components/IngredientPicker.tsx
+++ b/src/components/IngredientPicker.tsx
@@ -1,6 +1,6 @@
-import { useContext } from "react";
 import { AppContext } from "../App";
-import { ingredients } from "../services/SoupService";
+import { INGREDIENTS } from "../services/IngredientService";
+import { useContext } from "react";
 
 const IngredientPicker = () => {
   const appContext = useContext(AppContext);
@@ -22,7 +22,7 @@ const IngredientPicker = () => {
 
   return (
     <div>
-      {ingredients.map((ingredient) => (
+      {INGREDIENTS.map((ingredient) => (
         <button
           key={ingredient.name}
           onClick={() => {

--- a/src/components/SoupList.tsx
+++ b/src/components/SoupList.tsx
@@ -1,10 +1,11 @@
-import { getRankedSoups, ingredients } from "../services/SoupService";
 import { useContext, useEffect, useState } from "react";
 
 import { AppContext } from "../App";
+import { INGREDIENTS } from "../services/IngredientService";
 import Ingredient from "../models/Ingredient";
 import Soup from "../models/Soup";
 import SoupListItem from "./SoupListItem";
+import { getRankedSoups } from "../services/SoupService";
 
 const SoupList = () => {
   const appContext = useContext(AppContext);
@@ -13,8 +14,8 @@ const SoupList = () => {
   useEffect(() => {
     const selected =
       appContext?.toggledIngredients.reduce(
-        (agg: Array<Ingredient>, cur, idx) => {
-          if (cur) agg.push(ingredients[idx]);
+        (agg: Array<Ingredient>, toggled, idx) => {
+          if (toggled) agg.push(INGREDIENTS[idx]);
           return agg;
         },
         []

--- a/src/components/SoupListItem.tsx
+++ b/src/components/SoupListItem.tsx
@@ -87,6 +87,13 @@ const SoupIngredients = styled.div`
   margin-top: 0.3em;
   grid-column-start: 2;
   grid-row-start: 2;
+  display: flex;
+  align-items: center;
+`;
+
+const Ing = styled.img`
+  height: 1.1em;
+  padding: 0 0.3em 0 0.2em;
 `;
 
 const SoupListItem = (props: Soup) => {
@@ -97,7 +104,8 @@ const SoupListItem = (props: Soup) => {
       <SoupValue rarity={rarity}>{props.value}</SoupValue>{" "}
       <SoupTitle>{props.name}</SoupTitle>
       <SoupIngredients>
-        {props.ingredients[0].name} + {props.ingredients[1].name}
+        {props.ingredients[0].name} <Ing src={props.ingredients[0].svg} />+{" "}
+        {props.ingredients[1].name} <Ing src={props.ingredients[1].svg} />
       </SoupIngredients>
     </SoupListItemContainer>
   );

--- a/src/models/Ingredient.ts
+++ b/src/models/Ingredient.ts
@@ -1,6 +1,7 @@
 interface Ingredient {
   index: number;
   name: string;
+  svg: string;
 }
 
 export default Ingredient;

--- a/src/services/IngredientService.ts
+++ b/src/services/IngredientService.ts
@@ -1,0 +1,77 @@
+import BisausageSVG from "../ingredients/Bisausage.svg";
+import BluecapSVG from "../ingredients/Bluecap.svg";
+import BrineweedSVG from "../ingredients/Brineweed.svg";
+import ChickenberrySVG from "../ingredients/Chickenberry.svg";
+import CornShellSVG from "../ingredients/Corn Shell.svg";
+import GreenstalkSVG from "../ingredients/Greenstalk.svg";
+import Ingredient from "../models/Ingredient";
+import KaboChunksSVG from "../ingredients/Kabo Chunks.svg";
+import MammothMeatSVG from "../ingredients/Mammoth Meat.svg";
+import MasherYamSVG from "../ingredients/Masher Yam.svg";
+import OxygrassSVG from "../ingredients/Oxygrass.svg";
+import PinapuranaSVG from "../ingredients/Pinapura.svg";
+import PoisonpuffSVG from "../ingredients/Poisonpuff.svg";
+import SquidflySVG from "../ingredients/Squidfly.svg";
+import StabgrassSVG from "../ingredients/Stabgrass.svg";
+import StrawburiSVG from "../ingredients/Strawburi.svg";
+import SunblossomSVG from "../ingredients/Sunblossom.svg";
+import ThornbloomSVG from "../ingredients/Thornblossom.svg";
+import ThornstalkSVG from "../ingredients/Thornstalk.svg";
+import TomatySteakSVG from "../ingredients/Tomaty Steak.svg";
+import TsutavineSVG from "../ingredients/Tsutavine.svg";
+import ingredientsJson from "../data/ingredients.json";
+
+const getIngredientSVG = (ingredientName: string): string => {
+  switch (ingredientName) {
+    case "Bluecap":
+      return BluecapSVG;
+    case "Greenstalk":
+      return GreenstalkSVG;
+    case "Stabgrass":
+      return StabgrassSVG;
+    case "Brineweed":
+      return BrineweedSVG;
+    case "Tsutavine":
+      return TsutavineSVG;
+    case "Tomaty Steak":
+      return TomatySteakSVG;
+    case "Oxygrass":
+      return OxygrassSVG;
+    case "Corn Shell":
+      return CornShellSVG;
+    case "Chickenberry":
+      return ChickenberrySVG;
+    case "Bisausage":
+      return BisausageSVG;
+    case "Strawburi Filet":
+      return StrawburiSVG;
+    case "Sunblossom":
+      return SunblossomSVG;
+    case "Squidfly Chunk":
+      return SquidflySVG;
+    case "Pinapurana Filet":
+      return PinapuranaSVG;
+    case "Poisonpuff":
+      return PoisonpuffSVG;
+    case "Kabo Chunk":
+      return KaboChunksSVG;
+    case "Thornstalk":
+      return ThornstalkSVG;
+    case "Thornbloom":
+      return ThornbloomSVG;
+    case "Masher Yam":
+      return MasherYamSVG;
+    case "Mammoth Meat":
+      return MammothMeatSVG;
+    default:
+      return BluecapSVG;
+  }
+};
+
+const INGREDIENTS: Ingredient[] = ingredientsJson.map(({ name, index }) => ({
+  name,
+  index,
+  svg: getIngredientSVG(name),
+}));
+
+export { INGREDIENTS };

--- a/src/services/SoupService.ts
+++ b/src/services/SoupService.ts
@@ -1,10 +1,7 @@
 import Ingredient from "../models/Ingredient";
-import Soup from "../models/Soup";
 import RecipeMatrixItem from "../models/RecipeMatrixItem";
-import ingredientsJson from "../data/ingredients.json";
+import Soup from "../models/Soup";
 import recipeJson from "../data/soupMatrix.json";
-
-const ingredients: Ingredient[] = ingredientsJson;
 
 const recipeMatrix: RecipeMatrixItem[][] = recipeJson;
 
@@ -35,4 +32,4 @@ function getRankedSoups(selectedIngredients: Ingredient[]): Soup[] {
   return recipes;
 }
 
-export { ingredients, recipeMatrix, getRankedSoups };
+export { recipeMatrix, getRankedSoups };


### PR DESCRIPTION
Creates an `IngredientService` that exports the constant `INGREDIENTS`, which now contains additional information about how ingredients are drawn.

<img width="413" alt="Screen Shot 2022-06-08 at 9 35 15 PM" src="https://user-images.githubusercontent.com/20538779/172758797-fe82965a-3a92-4f52-94b5-e2e93851d6f4.png">

